### PR TITLE
Session/3

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_training/utils/logger.dart';
-import 'package:flutter_training/views/weather_view.dart';
+import 'package:flutter_training/views/start_up_view.dart';
 
 void main() {
   // Logger初期化
@@ -18,7 +18,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: const WeatherView(),
+      home: const StartUpView(),
     );
   }
 }

--- a/lib/views/start_up_view.dart
+++ b/lib/views/start_up_view.dart
@@ -12,28 +12,33 @@ class _StartUpViewState extends State<StartUpView> {
   @override
   void initState() {
     // Widgetの描画が完了するまで待機
-    WidgetsBinding.instance.endOfFrame;
+    WidgetsBinding.instance.endOfFrame.then((_) {
+      _awaitAndPush();
+    });
     super.initState();
   }
 
-  Future<void> waitAndPush() async {
+  Future<void> _awaitAndPush() async {
     // 500ミリ秒待機
     await Future<void>.delayed(
       const Duration(milliseconds: 500),
-    ).then((_) async {
-      // WeatherView に遷移
-      await Navigator.of(context).push(
-        MaterialPageRoute<void>(
-          builder: (context) => const WeatherView(),
-        ),
-      );
-      setState(() {});
-    });
+    );
+
+    if (!mounted) {
+      return;
+    }
+
+    // WeatherView に遷移
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (context) => const WeatherView(),
+      ),
+    );
+    await _awaitAndPush();
   }
 
   @override
   Widget build(BuildContext context) {
-    waitAndPush();
     return const Scaffold();
   }
 }

--- a/lib/views/start_up_view.dart
+++ b/lib/views/start_up_view.dart
@@ -10,23 +10,30 @@ class StartUpView extends StatefulWidget {
 
 class _StartUpViewState extends State<StartUpView> {
   @override
-  Widget build(BuildContext context) {
+  void initState() {
     // Widgetの描画が完了するまで待機
-    WidgetsBinding.instance.endOfFrame.then((_) async {
-      // 500ミリ秒待機
-      await Future<void>.delayed(
-        const Duration(milliseconds: 500),
-      ).then((_) async {
-        // WeatherView に遷移
-        await Navigator.of(context).push(
-          MaterialPageRoute<void>(
-            builder: (context) => const WeatherView(),
-          ),
-        );
-        // pop されると再描画
-        setState(() {});
-      });
+    WidgetsBinding.instance.endOfFrame;
+    super.initState();
+  }
+
+  Future<void> waitAndPush() async {
+    // 500ミリ秒待機
+    await Future<void>.delayed(
+      const Duration(milliseconds: 500),
+    ).then((_) async {
+      // WeatherView に遷移
+      await Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (context) => const WeatherView(),
+        ),
+      );
+      setState(() {});
     });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    waitAndPush();
     return const Scaffold();
   }
 }

--- a/lib/views/start_up_view.dart
+++ b/lib/views/start_up_view.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:flutter_training/utils/logger.dart';
+import 'package:flutter_training/views/weather_view.dart';
+import 'package:yumemi_weather/yumemi_weather.dart';
+
+class StartUpView extends StatefulWidget {
+  const StartUpView({super.key});
+
+  @override
+  State<StartUpView> createState() => _StartUpViewState();
+}
+
+class _StartUpViewState extends State<StartUpView> {
+  final _weatherClient = YumemiWeather();
+
+  SvgPicture? _currentWeather;
+
+  @override
+  void initState() {
+    WidgetsBinding.instance.endOfFrame.then((_) {
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (context) => const WeatherView(),
+        ),
+      );
+    });
+    super.initState();
+  }
+
+  String? _fetchWeather(YumemiWeather client) {
+    try {
+      final weather = client.fetchSimpleWeather();
+      return weather;
+    } on YumemiWeatherError catch (e) {
+      logger.shout(e);
+      return null;
+    }
+  }
+
+  SvgPicture _weatherToImage(String weather) {
+    return SvgPicture.asset('assets/images/$weather.svg');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final deviceWidth = MediaQuery.of(context).size.width;
+
+    return Scaffold(
+      body: Center(
+        child: Column(
+          children: [
+            const Spacer(),
+            SizedBox(
+              width: deviceWidth / 2,
+              child: Column(
+                children: [
+                  AspectRatio(
+                    aspectRatio: 1,
+                    child: _currentWeather ?? const Placeholder(),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            '** ℃',
+                            textAlign: TextAlign.center,
+                            style: Theme.of(context)
+                                .textTheme
+                                .labelLarge
+                                ?.copyWith(
+                                  color: Colors.blue,
+                                ),
+                          ),
+                        ),
+                        Expanded(
+                          child: Text(
+                            '** ℃',
+                            textAlign: TextAlign.center,
+                            style: Theme.of(context)
+                                .textTheme
+                                .labelLarge
+                                ?.copyWith(
+                                  color: Colors.red,
+                                ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: Column(
+                children: [
+                  const SizedBox(
+                    height: 80,
+                  ),
+                  SizedBox(
+                    width: deviceWidth / 2,
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: Center(
+                            child: TextButton(
+                              onPressed: () {},
+                              child: const Text('Close'),
+                            ),
+                          ),
+                        ),
+                        Expanded(
+                          child: Center(
+                            child: TextButton(
+                              onPressed: () {
+                                final weather = _fetchWeather(_weatherClient);
+                                if (weather == null) {
+                                  return;
+                                } else {
+                                  setState(() {
+                                    _currentWeather = _weatherToImage(weather);
+                                  });
+                                }
+                              },
+                              child: const Text('Reload'),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/start_up_view.dart
+++ b/lib/views/start_up_view.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/svg.dart';
-import 'package:flutter_training/utils/logger.dart';
 import 'package:flutter_training/views/weather_view.dart';
-import 'package:yumemi_weather/yumemi_weather.dart';
 
 class StartUpView extends StatefulWidget {
   const StartUpView({super.key});
@@ -12,131 +9,24 @@ class StartUpView extends StatefulWidget {
 }
 
 class _StartUpViewState extends State<StartUpView> {
-  final _weatherClient = YumemiWeather();
-
-  SvgPicture? _currentWeather;
-
-  @override
-  void initState() {
-    WidgetsBinding.instance.endOfFrame.then((_) {
-      Navigator.of(context).push(
-        MaterialPageRoute<void>(
-          builder: (context) => const WeatherView(),
-        ),
-      );
-    });
-    super.initState();
-  }
-
-  String? _fetchWeather(YumemiWeather client) {
-    try {
-      final weather = client.fetchSimpleWeather();
-      return weather;
-    } on YumemiWeatherError catch (e) {
-      logger.shout(e);
-      return null;
-    }
-  }
-
-  SvgPicture _weatherToImage(String weather) {
-    return SvgPicture.asset('assets/images/$weather.svg');
-  }
-
   @override
   Widget build(BuildContext context) {
-    final deviceWidth = MediaQuery.of(context).size.width;
-
-    return Scaffold(
-      body: Center(
-        child: Column(
-          children: [
-            const Spacer(),
-            SizedBox(
-              width: deviceWidth / 2,
-              child: Column(
-                children: [
-                  AspectRatio(
-                    aspectRatio: 1,
-                    child: _currentWeather ?? const Placeholder(),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 16),
-                    child: Row(
-                      children: [
-                        Expanded(
-                          child: Text(
-                            '** ℃',
-                            textAlign: TextAlign.center,
-                            style: Theme.of(context)
-                                .textTheme
-                                .labelLarge
-                                ?.copyWith(
-                                  color: Colors.blue,
-                                ),
-                          ),
-                        ),
-                        Expanded(
-                          child: Text(
-                            '** ℃',
-                            textAlign: TextAlign.center,
-                            style: Theme.of(context)
-                                .textTheme
-                                .labelLarge
-                                ?.copyWith(
-                                  color: Colors.red,
-                                ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Expanded(
-              child: Column(
-                children: [
-                  const SizedBox(
-                    height: 80,
-                  ),
-                  SizedBox(
-                    width: deviceWidth / 2,
-                    child: Row(
-                      children: [
-                        Expanded(
-                          child: Center(
-                            child: TextButton(
-                              onPressed: () {},
-                              child: const Text('Close'),
-                            ),
-                          ),
-                        ),
-                        Expanded(
-                          child: Center(
-                            child: TextButton(
-                              onPressed: () {
-                                final weather = _fetchWeather(_weatherClient);
-                                if (weather == null) {
-                                  return;
-                                } else {
-                                  setState(() {
-                                    _currentWeather = _weatherToImage(weather);
-                                  });
-                                }
-                              },
-                              child: const Text('Reload'),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
+    // Widgetの描画が完了するまで待機
+    WidgetsBinding.instance.endOfFrame.then((_) async {
+      // 500ミリ秒待機
+      await Future<void>.delayed(
+        const Duration(milliseconds: 500),
+      ).then((_) async {
+        // WeatherView に遷移
+        await Navigator.of(context).push(
+          MaterialPageRoute<void>(
+            builder: (context) => const WeatherView(),
+          ),
+        );
+        // pop されると再描画
+        setState(() {});
+      });
+    });
+    return const Scaffold();
   }
 }

--- a/lib/views/weather_view.dart
+++ b/lib/views/weather_view.dart
@@ -93,7 +93,7 @@ class _WeatherViewState extends State<WeatherView> {
                         Expanded(
                           child: Center(
                             child: TextButton(
-                              onPressed: () {},
+                              onPressed: Navigator.of(context).pop,
                               child: const Text('Close'),
                             ),
                           ),


### PR DESCRIPTION
## 課題

close #4 

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] [StatefulWidget](https://api.flutter.dev/flutter/widgets/StatefulWidget-class.html) を継承した Widget で構築された新しい画面を追加する
- [x] アプリ起動時に新しい画面に遷移する
- [x] 新しい画面が表示されたら、0.5 秒後に前回まで作っていた画面に遷移する
  -  first build は initState 内で [WidgetsBinding.instance.endOfFrame](https://api.flutter.dev/flutter/scheduler/SchedulerBinding/endOfFrame.html)でWidgetの描画を待機してから遷移
  - 以降は、再起処理のみ
- [x] 前回まで作っていた画面の Close ボタンをタップすると画面を閉じる
  - Navigator.of(context).popで実装 

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

| expected | actual |
|----------|--------|
| <img src = 'https://github.com/yumemi-inc/flutter-training-template/blob/main/docs/sessions/images/lifecycle/demo.gif?raw=true' width = '300' > |  <img src = 'https://user-images.githubusercontent.com/89247188/202106650-0c71e9db-6a1c-4462-88dc-d68756535671.gif' width = '300'>|
