### PR TITLE
Session/4

### DIFF
--- a/lib/views/start_up_view.dart
+++ b/lib/views/start_up_view.dart
@@ -8,17 +8,24 @@ class StartUpView extends StatefulWidget {
   State<StartUpView> createState() => _StartUpViewState();
 }
 
-class _StartUpViewState extends State<StartUpView> {
+class _StartUpViewState extends State<StartUpView> with _AwaitAndPopStateMixin {
   @override
   void initState() {
     // Widgetの描画が完了するまで待機
     WidgetsBinding.instance.endOfFrame.then((_) {
-      _awaitAndPush();
+      awaitAndPush();
     });
     super.initState();
   }
 
-  Future<void> _awaitAndPush() async {
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold();
+  }
+}
+
+mixin _AwaitAndPopStateMixin on State<StartUpView> {
+  Future<void> awaitAndPush() async {
     // 500ミリ秒待機
     await Future<void>.delayed(
       const Duration(milliseconds: 500),
@@ -34,11 +41,6 @@ class _StartUpViewState extends State<StartUpView> {
         builder: (context) => const WeatherView(),
       ),
     );
-    await _awaitAndPush();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold();
+    await awaitAndPush();
   }
 }

--- a/lib/views/start_up_view.dart
+++ b/lib/views/start_up_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_training/utils/logger.dart';
 import 'package:flutter_training/views/weather_view.dart';
 
 class StartUpView extends StatefulWidget {
@@ -11,11 +12,8 @@ class StartUpView extends StatefulWidget {
 class _StartUpViewState extends State<StartUpView> with _AwaitAndPopStateMixin {
   @override
   void initState() {
-    // Widgetの描画が完了するまで待機
-    WidgetsBinding.instance.endOfFrame.then((_) {
-      awaitAndPush();
-    });
     super.initState();
+    awaitAndPush();
   }
 
   @override
@@ -25,6 +23,14 @@ class _StartUpViewState extends State<StartUpView> with _AwaitAndPopStateMixin {
 }
 
 mixin _AwaitAndPopStateMixin on State<StartUpView> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.endOfFrame.then((_) {
+      logger.info('build done');
+    });
+  }
+
   Future<void> awaitAndPush() async {
     // 500ミリ秒待機
     await Future<void>.delayed(

--- a/lib/views/start_up_view.dart
+++ b/lib/views/start_up_view.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_training/utils/logger.dart';
 import 'package:flutter_training/views/weather_view.dart';
 
 class StartUpView extends StatefulWidget {
@@ -9,26 +8,10 @@ class StartUpView extends StatefulWidget {
   State<StartUpView> createState() => _StartUpViewState();
 }
 
-class _StartUpViewState extends State<StartUpView> with _AwaitAndPopStateMixin {
+class _StartUpViewState extends State<StartUpView> with AfterLayoutMixin {
   @override
-  void initState() {
-    super.initState();
+  void afterFirstLayout() {
     awaitAndPush();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold();
-  }
-}
-
-mixin _AwaitAndPopStateMixin on State<StartUpView> {
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.endOfFrame.then((_) {
-      logger.info('build done');
-    });
   }
 
   Future<void> awaitAndPush() async {
@@ -49,4 +32,24 @@ mixin _AwaitAndPopStateMixin on State<StartUpView> {
     );
     await awaitAndPush();
   }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold();
+  }
+}
+
+mixin AfterLayoutMixin<T extends StatefulWidget> on State<T> {
+  @override
+  void initState() {
+    super.initState();
+    // 描画完了を待機
+    WidgetsBinding.instance.endOfFrame.then((_) {
+      if (mounted) {
+        afterFirstLayout();
+      }
+    });
+  }
+  
+  void afterFirstLayout() {}
 }


### PR DESCRIPTION
## 課題

close #5 

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] レイアウトが表示された後に何かしらの処理を行う [Mixin](https://dart.dev/guides/language/language-tour#adding-features-to-a-class-mixins) を作成する
 - buildを待機する処理を保持するMixinを作成
 - [x] [Session3](https://github.com/trm11tkr/flutter-training-yumemi/issues/4) で作成した以下の処理を [Mixin](https://dart.dev/guides/language/language-tour#adding-features-to-a-class-mixins) を使って書き直す
  - Mixinにレイアウトの完了後に実行するメソッドを定義（デフォルトは何もしない）
  - Mixin使用クラスで、overrideして遷移処理を追加

参考
https://pub.dev/packages/after_layout

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

動作は前回と変更なし

<img src = 'https://user-images.githubusercontent.com/89247188/202329497-a8eb5412-dd56-401b-81a4-a036091747b0.gif' width = '400'>

